### PR TITLE
Fix web search documents output

### DIFF
--- a/adaptive_rag_streamlit_app.py
+++ b/adaptive_rag_streamlit_app.py
@@ -467,7 +467,8 @@ def initialize_langgraph(local_llm):
         docs = web_search_tool.invoke({"query": question})
         web_results = "\n".join([d["content"] for d in docs])
         web_results = Document(page_content=web_results)
-        return {"documents": web_results, "question": question}
+        # Downstream components expect a list of Documents
+        return {"documents": [web_results], "question": question}
 
     # Define conditional edges
     def route_question(state):


### PR DESCRIPTION
## Summary
- fix `web_search` to return a list of `Document`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bf74926d0832cba115e356461d41d