### PR TITLE
Update GraphState document type

### DIFF
--- a/adaptive_rag_streamlit_app.py
+++ b/adaptive_rag_streamlit_app.py
@@ -417,11 +417,11 @@ def initialize_langgraph(local_llm):
         Attributes:
             question: question
             generation: LLM generation
-            documents: list of documents
+            documents: list of LangChain ``Document`` objects
         """
         question: str
         generation: str
-        documents: List[str]
+        documents: List[Document]
     
     # Define the nodes
     def retrieve(state):


### PR DESCRIPTION
## Summary
- use `List[Document]` for GraphState documents field
- clarify docstring that documents are LangChain Document objects

## Testing
- `python -m py_compile adaptive_rag_streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_684e74076930832c9b3c9fa2ab012171